### PR TITLE
Iacono/logging updates

### DIFF
--- a/lib/etl.rb
+++ b/lib/etl.rb
@@ -177,17 +177,20 @@ private
   def default_logger
     ::Logger.new(STDOUT).tap do |logger|
       logger.formatter = proc do |severity, datetime, progname, msg|
-        lead =  "[#{datetime}] #{severity} #{msg[:event_type]}"
-        desc =  "\"#{msg[:emitter].description || 'no description given'}\""
-        desc += " (object #{msg[:emitter].object_id})"
+        event_details =  "[#{datetime}] #{severity} #{msg[:event_type]}"
+
+        emitter_details =  "\"#{msg[:emitter].description || 'no description given'}\""
+        emitter_details += " (object #{msg[:emitter].object_id})"
+
+        leadin = "#{event_details} for #{emitter_details}"
 
         case msg[:event_type]
         when :query_start
-          "#{lead} for #{desc}\n#{msg[:sql]}\n"
+          "#{leadin}\n#{msg[:sql]}\n"
         when :query_complete
-          "#{lead} for #{desc} runtime: #{msg[:runtime]}s\n"
+          "#{leadin} runtime: #{msg[:runtime]}s\n"
         else
-          "#{msg}"
+          "#{leadin}: #{msg[:message]}\n"
         end
       end
     end


### PR DESCRIPTION
@JackDanger 

updating logging methods so they can be leveraged by others.

little background: we were extending the functionality to support safe iteration ...

``` ruby
module ActsAsSafeIterator
  def etl *args, &block
    begin
      super *args, &block
    rescue Exception => e
      raise e unless e.message =~ /comparison of .* with nil failed/

      self.debug(event_type: :skipped_iteration,
                 message:    "start, step, stop (or some combo) was nil.") if self.logger
    end
  end
end

require './acts_as_safe_iterator'

etl = ETL.new.config do |e|
  e.before_etl do
    puts "before ETLing!"
  end

  e.start do
    nil # yolo
  end

  e.step do
    1
  end

  e.stop do
    42
  end

  e.etl do |e, lbound, ubound|
    puts "step: #{step}, lbound: #{lbound}, ubound: #{ubound}" # won't run, will raise exception due to nil start
  end

  e.after_etl do
    puts "after ETLing!"
  end
end

etl.extend ActsAsSafeIterator

etl.run
# before etling!
# [2013-06-27 13:56:21 -0700] DEBUG iteration skipped for "no description given" (object 70238181346100) start, step, stop (or some combo) was nil..
# after ETLing!
```
